### PR TITLE
improve htaccess check

### DIFF
--- a/src/Localhost/index.php
+++ b/src/Localhost/index.php
@@ -11,8 +11,9 @@
  * 1.1 Added state of services
  * 1.2 Added display of joomla info in sites list
  * 1.3 Fixes some issues with the display of the table infos
+ * 1.4 Improve htaccess check
  *
- * THISVERSION=1.3
+ * THISVERSION=1.4
  */
 
 # Determine oath of local etc folder
@@ -94,13 +95,22 @@ function getJoomlaInfo ( $sitename ): array
 		$siteConfig[ trim( $key ) ] = trim( $value );
 	}
 
-	if ( file_exists( $siteConfig['PATH'] . '/.htaccess') )
-	{
-		echo $siteConfig['HTACCESS'] = 'Yes';
-	}
-	else
-	{
-		echo $siteConfig[ 'HTACCESS' ] = 'No';
+	if (isset($siteConfig['PATH']) && file_exists($siteConfig['PATH'] . '/.htaccess')) {
+		$htaccessContent = trim(file_get_contents($siteConfig['PATH'] . '/.htaccess'));
+
+		// Checks that the file is not empty
+		if (!empty($htaccessContent)) {
+			// Check important instructions
+			if (preg_match('/RewriteEngine\s+On|Options\s+-Indexes|Deny\s+from\s+all|Require\s+all\s+denied/i', $htaccessContent)) {
+				$siteConfig['HTACCESS'] = 'Yes';
+			} else {
+				$siteConfig['HTACCESS'] = 'Minimal';
+			}
+		} else {
+			$siteConfig['HTACCESS'] = 'Empty';
+		}
+	} else {
+		$siteConfig['HTACCESS'] = 'No';
 	}
 
 	return $siteConfig;


### PR DESCRIPTION
This PR solves the incorrect output of the htaccess check above the table.
![Bildschirmfoto 2025-03-16 um 13 28 08](https://github.com/user-attachments/assets/6d298b77-756a-47db-92d0-dc161cfcb959)

Furthermore, the check of the htaccess file has been significantly optimised to be less error-prone.

What happens here?
- If no file exists, the value **No** remains.
- If the file exists but is empty, the value **Empty** remains.
- If the file contains a.htaccess but only unimportant content, **Minimal** is set.
- If the file contains important configuration instructions (RewriteEngine On, Options -Indexes, etc.), **Yes** is set.

### Expected Behavior in the Table

| File Exists? | Contains Relevant Rules? | Value for `.htaccess` |
|-------------|-------------------------|----------------------|
| ❌ No      | ❌ No                     | `No`                |
| ✅ Yes     | ❌ No (empty file)        | `Empty`             |
| ✅ Yes     | ❌ No (only comments, blank lines) | `Minimal`          |
| ✅ Yes     | ✅ Yes (`RewriteEngine On`, etc.) | `Yes`               |

This ensures that `.htaccess` is correctly categorized based on its existence and content.